### PR TITLE
WPW-129 import names fixed

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -6,10 +6,10 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
-	"github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/client"
-	"github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/service/cardnotpresent"
-	"github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/service/tokenization"
-	"github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/types"
+	"github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/client"
+	"github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/service/cardnotpresent"
+	"github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/service/tokenization"
+	"github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/types"
 )
 
 // Flags

--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -2,8 +2,8 @@ package client
 
 import (
 	log "github.com/sirupsen/logrus"
-	"github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/service/cardnotpresent"
-	"github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/service/tokenization"
+	"github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/service/cardnotpresent"
+	"github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/service/tokenization"
 )
 
 // Client enables interaction with the Worldpay API

--- a/sdk/client/connectionImpl.go
+++ b/sdk/client/connectionImpl.go
@@ -12,10 +12,10 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/wptechinnovation/worldpay-securenet-lib-go/sdk"
-	"github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/utils"
+	"github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk"
+	"github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/utils"
 
-	"github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/service"
+	"github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/service"
 )
 
 // ConnectionImpl Required details to make a connection to the API server

--- a/sdk/service/cardnotpresent/chargetokenrequest.go
+++ b/sdk/service/cardnotpresent/chargetokenrequest.go
@@ -1,6 +1,6 @@
 package cardnotpresent
 
-import "github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/types"
+import "github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/types"
 
 // ChargeTokenRequest represents a request to charge a token where the card is not present
 type ChargeTokenRequest struct {

--- a/sdk/service/cardnotpresent/service.go
+++ b/sdk/service/cardnotpresent/service.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 
 	"github.com/sirupsen/logrus"
-	"github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/service"
+	"github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/service"
 )
 
 // Service defines functions related card not present transactions

--- a/sdk/service/tokenization/service.go
+++ b/sdk/service/tokenization/service.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/service"
+	"github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/service"
 )
 
 // Service defines Tokenization related functions

--- a/sdk/service/tokenization/tokenizecardrequest.go
+++ b/sdk/service/tokenization/tokenizecardrequest.go
@@ -1,6 +1,6 @@
 package tokenization
 
-import "github.com/wptechinnovation/worldpay-securenet-lib-go/sdk/types"
+import "github.com/WPTechInnovation/worldpay-securenet-lib-go/sdk/types"
 
 // TokenizeCardRequest represents a request to convert a payment card to a SecureNet token
 type TokenizeCardRequest struct {


### PR DESCRIPTION
Changed from lowercase to actual URL.
Without it GO can enter filename case conflict.
Repository name (WPTechInnovation) is case sensitive and used in several places thus shouldn't be changed.